### PR TITLE
Upgrading to the latest versions of dependencies

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,9 +1,12 @@
 {
-    "projects": [
-        "src",
-        "test"
-    ],
     "sdk": {
         "version": "1.0.0-preview2-003131"
-    }
+    },
+    "projects": [
+        "src",
+        "src/bundles",
+        "test",
+        "test/client",
+        "test/server"
+    ]
 }

--- a/src/Tug.Base/project.json
+++ b/src/Tug.Base/project.json
@@ -24,14 +24,14 @@
   },
 
   "dependencies": {
-    "Microsoft.Composition": "1.0.30",
+    "Microsoft.Composition": "1.0.31",
     "Microsoft.Extensions.PlatformAbstractions": "1.1.0",
-    "Microsoft.Extensions.DependencyModel": "1.1.0",
+    "Microsoft.Extensions.DependencyModel": "1.1.2",
 
-    "Microsoft.Extensions.Logging": "1.1.0",
-    "Microsoft.Extensions.Configuration": "1.1.0",
+    "Microsoft.Extensions.Logging": "1.1.2",
+    "Microsoft.Extensions.Configuration": "1.1.2",
 
-    "Microsoft.AspNetCore.Mvc": "1.1.0"
+    "Microsoft.AspNetCore.Mvc": "1.1.3"
   },
 
   "frameworks": {

--- a/src/Tug.Client/project.json
+++ b/src/Tug.Client/project.json
@@ -26,16 +26,16 @@
   },
 
   "dependencies": {
-    "Microsoft.Extensions.Logging.Console": "1.1.0",
-    "NLog.Extensions.Logging": "1.0.0-rtm-alpha5",
-    "Microsoft.Extensions.CommandLineUtils": "1.1.0",
-    "Microsoft.Extensions.Configuration.Json": "1.1.0",
-    "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.1.0",
-    "Microsoft.Extensions.Configuration.CommandLine": "1.1.0",
-    "Microsoft.Extensions.Configuration.UserSecrets": "1.1.0",
-    "Microsoft.Extensions.Configuration.Binder": "1.1.0",
+    "Microsoft.Extensions.Logging.Console": "1.1.2",
+    "NLog.Extensions.Logging": "1.0.0-rtm-beta5",
+    "Microsoft.Extensions.CommandLineUtils": "1.1.1",
+    "Microsoft.Extensions.Configuration.Json": "1.1.2",
+    "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.1.2",
+    "Microsoft.Extensions.Configuration.CommandLine": "1.1.2",
+    "Microsoft.Extensions.Configuration.UserSecrets": "1.1.2",
+    "Microsoft.Extensions.Configuration.Binder": "1.1.2",
     
-    "Newtonsoft.Json": "9.0.1",
+    "Newtonsoft.Json": "10.0.3",
 
     "Tug.Base": {
       "target": "project"
@@ -55,7 +55,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.1"
+          "version": "1.1.2"
         },
 
         // For System.Net.WebProxy and others

--- a/src/Tug.Server.Base/project.json
+++ b/src/Tug.Server.Base/project.json
@@ -24,10 +24,10 @@
   },
 
   "dependencies": {
-    "Microsoft.Extensions.Logging": "1.1.0",
-    "Microsoft.Extensions.Configuration": "1.1.0",
+    "Microsoft.Extensions.Logging": "1.1.2",
+    "Microsoft.Extensions.Configuration": "1.1.2",
 
-    "Microsoft.AspNetCore.Mvc": "1.1.1",
+    "Microsoft.AspNetCore.Mvc": "1.1.3",
 
     "Tug.Base": {
       "target": "project"

--- a/src/Tug.Server.FaaS.AwsLambda/FunctionMain.cs
+++ b/src/Tug.Server.FaaS.AwsLambda/FunctionMain.cs
@@ -83,6 +83,13 @@ namespace Tug.Server.FaaS.AwsLambda
             }
         }
 
+        // We no longer need to do this kludge since this PR was accepted:
+        //    https://github.com/aws/aws-lambda-dotnet/pull/75
+        //
+        // We will delete this bit of old reference code in a forthcoming
+        // commit after testing and some usage confirms expected behavior
+
+        /*
         #region -- Temporary Binary Response Content Kludge --
 
         // We've temporarily re-implemented some of the functionality in the base class so that
@@ -195,5 +202,6 @@ namespace Tug.Server.FaaS.AwsLambda
         // }
 
         #endregion -- Temporary Binary Response Content Kludge --
+        */
     }
 }

--- a/src/Tug.Server.FaaS.AwsLambda/project.json
+++ b/src/Tug.Server.FaaS.AwsLambda/project.json
@@ -26,39 +26,42 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.1"
+      "version": "1.1.2"
     },
 
-    "Microsoft.Extensions.Configuration.Json": "1.1.0",
-    "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.1.0",
-    "Microsoft.Extensions.Configuration.FileExtensions": "1.1.0",
-    "Microsoft.Extensions.Configuration.Binder": "1.1.0",
-    "Microsoft.Extensions.Logging": "1.1.0",
-    "Microsoft.Extensions.Options.ConfigurationExtensions": "1.1.0",
+    "Microsoft.Extensions.Configuration.Json": "1.1.2",
+    "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.1.2",
+    "Microsoft.Extensions.Configuration.FileExtensions": "1.1.2",
+    "Microsoft.Extensions.Configuration.Binder": "1.1.2",
+    "Microsoft.Extensions.Logging": "1.1.2",
+    "Microsoft.Extensions.Options.ConfigurationExtensions": "1.1.2",
 
     // For testing out on dev-local
-    "Microsoft.AspNetCore.Server.Kestrel": "1.1.0",
-    "Microsoft.AspNetCore.Server.IISIntegration": "1.1.0",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.1.2",
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.1.2",
 
-    "Microsoft.AspNetCore.Hosting": "1.1.0",
-    "Microsoft.AspNetCore.Mvc": "1.1.1",
-    "Microsoft.AspNetCore.Routing": "1.1.0",
+    "Microsoft.AspNetCore.Hosting": "1.1.2",
+    "Microsoft.AspNetCore.Mvc": "1.1.3",
+    "Microsoft.AspNetCore.Routing": "1.1.2",
 
-    "AWSSDK.Core": "3.3.8.2",
-    "AWSSDK.Extensions.NETCore.Setup": "3.3.0.3",
-    "AWSSDK.DynamoDBv2": "3.3.2.1",
-    "AWSSDK.S3": "3.3.5.7",
-    "AWSSDK.CloudFront": "3.3.2.3",
+    "AWSSDK.Core": "3.3.14.2",
+    "AWSSDK.IdentityManagement":"3.3.4",
+    "AWSSDK.CloudFormation":"3.3.5.3",
+    "AWSSDK.Extensions.NETCore.Setup": "3.3.1",
+    "AWSSDK.DynamoDBv2": "3.3.4.13",
+    "AWSSDK.S3": "3.3.7",
+    "AWSSDK.CloudFront": "3.3.4.1",
+    "AWSSDK.Lambda":"3.3.7",
 
     "Amazon.Lambda.Core": "1.0.0",
-    "Amazon.Lambda.APIGatewayEvents": "1.0.2",
-    "Amazon.Lambda.Serialization.Json": "1.0.1",
-    "Amazon.Lambda.AspNetCoreServer": "0.9.0-preview1",
-    "Amazon.Lambda.Logging.AspNetCore": "1.0.0",
+    "Amazon.Lambda.APIGatewayEvents": "1.1.0",
+    "Amazon.Lambda.Serialization.Json": "1.1.0",
+    "Amazon.Lambda.AspNetCoreServer": "0.10.2-preview1",
+    "Amazon.Lambda.Logging.AspNetCore": "1.1.0",
     
     "Amazon.Lambda.Tools": {
       "type": "build",
-      "version": "1.3.0-preview1"
+      "version": "1.6.0"
     },
 
     "Tug.Base": {
@@ -70,7 +73,7 @@
   },
 
   "tools": {
-    "Amazon.Lambda.Tools" : "1.3.0-preview1"
+    "Amazon.Lambda.Tools" : "1.6.0"
   },
 
   "publishOptions": {

--- a/src/Tug.Server/Startup.cs
+++ b/src/Tug.Server/Startup.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Converters;
 using NLog.Extensions.Logging;
+using NLog.Web;
 using Tug.Server.Configuration;
 using Tug.Server.Filters;
 using Tug.Server.Util;

--- a/src/Tug.Server/project.json
+++ b/src/Tug.Server/project.json
@@ -62,22 +62,22 @@
   },
 
   "dependencies": {
-    "Microsoft.Extensions.Logging.Console": "1.1.0",
-    "NLog.Extensions.Logging": "1.0.0-rtm-alpha5",
+    "Microsoft.Extensions.Logging.Console": "1.1.2",
+    "NLog.Web.AspNetCore": "4.4.1",
 
-    "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.1.0",
-    "Microsoft.Extensions.Configuration.FileExtensions": "1.1.0",
-    "Microsoft.Extensions.Configuration.Json": "1.1.0",
-    "Microsoft.Extensions.Configuration.CommandLine": "1.1.0",
-    "Microsoft.Extensions.Configuration.UserSecrets": "1.1.0",
-    "Microsoft.Extensions.Options.ConfigurationExtensions": "1.1.0",
+    "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.1.2",
+    "Microsoft.Extensions.Configuration.FileExtensions": "1.1.2",
+    "Microsoft.Extensions.Configuration.Json": "1.1.2",
+    "Microsoft.Extensions.Configuration.CommandLine": "1.1.2",
+    "Microsoft.Extensions.Configuration.UserSecrets": "1.1.2",
+    "Microsoft.Extensions.Options.ConfigurationExtensions": "1.1.2",
 
-    "Microsoft.AspNetCore.Diagnostics": "1.1.0",
-    "Microsoft.AspNetCore.Routing": "1.1.0",
-    "Microsoft.AspNetCore.Mvc": "1.1.1",
+    "Microsoft.AspNetCore.Diagnostics": "1.1.2",
+    "Microsoft.AspNetCore.Routing": "1.1.2",
+    "Microsoft.AspNetCore.Mvc": "1.1.3",
 
-    "Microsoft.AspNetCore.Server.IISIntegration": "1.1.0",
-    "Microsoft.AspNetCore.Server.Kestrel": "1.1.0",
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.1.2",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.1.2",
 
     "Tug.Base": {
       "target": "project"
@@ -102,7 +102,7 @@
         "Microsoft.NETCore.App": {
           // This will generate a framework-dependent deployment
           "type": "platform",
-          "version": "1.0.1"
+          "version": "1.1.2"
         },
         "System.Security.Cryptography.Algorithms": "4.3.0"
       }

--- a/test/Tug.Ext-tests-aux/project.json
+++ b/test/Tug.Ext-tests-aux/project.json
@@ -25,7 +25,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.1"
+          "version": "1.1.2"
         }
       }
     },

--- a/test/Tug.Ext-tests/project.json
+++ b/test/Tug.Ext-tests/project.json
@@ -21,10 +21,10 @@
     // "xunit": "2.1.0",
     // "dotnet-test-xunit": "1.0.0-rc2-192208-24"
 
-    "Microsoft.Extensions.Logging": "1.1.0",
+    "Microsoft.Extensions.Logging": "1.1.2",
 
     "dotnet-test-mstest": "1.1.2-preview",
-    "MSTest.TestFramework": "1.1.11",
+    "MSTest.TestFramework": "1.1.18",
 
     // Assemblies under test
     "Tug.Base": {
@@ -46,7 +46,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.1"
+          "version": "1.1.2"
         },
         "System.Runtime.Loader": "4.3.0"
       }

--- a/test/Tug.UnitTesting/project.json
+++ b/test/Tug.UnitTesting/project.json
@@ -19,7 +19,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.1"
+          "version": "1.1.2"
         }
       },
       "imports": [

--- a/test/client/Tug.Client-tests/project.json
+++ b/test/client/Tug.Client-tests/project.json
@@ -37,7 +37,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.1"
+          "version": "1.1.2"
         }
       },
       "imports": [

--- a/test/server/Tug.Server-itests/project.json
+++ b/test/server/Tug.Server-itests/project.json
@@ -32,7 +32,7 @@
     "MSTest.TestFramework": "1.1.11",
 
     // ASP.NET Core Test Host
-    "Microsoft.AspNetCore.TestHost": "1.1.0",
+    "Microsoft.AspNetCore.TestHost": "1.1.2",
 
     // Assemblies with additional test support
     "Tug.UnitTesting": {
@@ -67,7 +67,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.1"
+          "version": "1.1.2"
         },
         "System.Security.Cryptography.Algorithms": "4.3.0"
       }

--- a/test/server/Tug.Server.FaaS.AwsLambda-tests/project.json
+++ b/test/server/Tug.Server.FaaS.AwsLambda-tests/project.json
@@ -6,16 +6,16 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.1"
+      "version": "1.1.2"
     },
 
     "Microsoft.DotNet.InternalAbstractions": "1.0.0",
 
     "Amazon.Lambda.Core": "1.0.0*",
-    "Amazon.Lambda.APIGatewayEvents": "1.0.2",
+    "Amazon.Lambda.APIGatewayEvents": "1.1.0",
     "Amazon.Lambda.TestUtilities": "1.0.0",
 
-    "xunit": "2.1.0-*",
+    "xunit": "2.2.0-*",
     "dotnet-test-xunit": "2.2.0-*",
 
     "Tug.Server.FaaS.AwsLambda": {


### PR DESCRIPTION
* Moving to more recent versions of almost all dependencies in
preparation for move to SDK 1.0.4.
* This should make the move to the released SDK smoother with more
compatible versions of the various libraries.
* We leave the MSTest libs alone for now as the later versions exhibit
different behavior.