### PR TITLE
invalid json in sample file

### DIFF
--- a/src/bundles/Tug.Server-ps5/posh-res/samples/hosting.json.sample
+++ b/src/bundles/Tug.Server-ps5/posh-res/samples/hosting.json.sample
@@ -8,6 +8,6 @@
 	// "captureStartupErrors": "false",
 	// "contentRoot": ".",
 	// "detailedErrors": "false",
-	// "urls" = "http://*:5000"
+	// "urls" : "http://*:5000"
 
 }


### PR DESCRIPTION
After trying tug out found that the sample hosting file consisted of invalid json.

Simple fix but should help others in the future.